### PR TITLE
update tor-chroot-update for wheezy

### DIFF
--- a/tor-chroot-update.sh
+++ b/tor-chroot-update.sh
@@ -57,7 +57,7 @@ if [ -f $DEFAULTSFILE ] ; then
 fi
 
 echo "Trying to chroot into $TORCHROOT..."
-/usr/sbin/chroot $TORCHROOT /usr/sbin/tor $*
+/usr/sbin/chroot --userspec debian-tor:debian-tor $TORCHROOT /usr/sbin/tor $*
 EOF
 chmod +x $TORCHROOT/usr/sbin/tor-chroot.sh
 

--- a/tor-chroot-update.sh
+++ b/tor-chroot-update.sh
@@ -9,7 +9,7 @@ TORCHROOT=/home/tor-chroot
 # Prep the chroot
 mkdir -p $TORCHROOT
 mkdir -p $TORCHROOT/{root,etc/tor/,dev,lib,var/run/tor/,var/lib/tor/,var/log/tor/}/
-chown debian-tor:debian-tor $TORCHROOT{/var/lib/tor,/var/run/tor,/var/log/tor}
+chown debian-tor:debian-tor $TORCHROOT{/root,/var/lib/tor,/var/run/tor,/var/log/tor}
 chmod 750 $TORCHROOT{/var/lib/tor,/var/run/tor,/var/log/tor}
 ls -al $TORCHROOT{/var/lib/tor,/var/run/tor,/var/log/tor}
 

--- a/tor-chroot-update.sh
+++ b/tor-chroot-update.sh
@@ -28,6 +28,7 @@ cp /lib/x86_64-linux-gnu/libnsl.so.1 $TORCHROOT/lib/libnsl.so.1
 cp /lib/x86_64-linux-gnu/librt.so.1 $TORCHROOT/lib/librt.so.1
 cp /lib/x86_64-linux-gnu/libresolv.so.2 $TORCHROOT/lib/libresolv.so.2
 cp /lib/x86_64-linux-gnu/ld-linux-x86-64.so.2 $TORCHROOT/lib64/ld-linux-x86-64.so.2
+cp /usr/lib/x86_64-linux-gnu/libseccomp.so.2 $TORCHROOT/lib/libseccomp.so.2
 
 # More generic libs
 cp /lib/x86_64-linux-gnu/libnss* /lib/x86_64-linux-gnu/libnsl* /lib/x86_64-linux-gnu/libresolv* \

--- a/tor-chroot-update.sh
+++ b/tor-chroot-update.sh
@@ -38,13 +38,6 @@ cp /lib/x86_64-linux-gnu/libnss* /lib/x86_64-linux-gnu/libnsl* /lib/x86_64-linux
 mkdir -p $TORCHROOT/usr/sbin
 cp /usr/sbin/tor  $TORCHROOT/usr/sbin/tor
 
-# Copy over geoip
-mkdir -p $TORCHROOT/usr/share/tor/
-cp /usr/share/tor/geoip $TORCHROOT/usr/share/tor/geoip
-
-# copy over the tor-exit-notice.html
-cp /etc/tor/tor-exit-notice.html $TORCHROOT/etc/tor/tor-exit-notice.html
-
 # Copy over the Tor chroot wrapper script
 cat << 'EOF' > $TORCHROOT/usr/sbin/tor-chroot.sh
 #!/bin/bash -x

--- a/tor-chroot-update.sh
+++ b/tor-chroot-update.sh
@@ -8,7 +8,7 @@ TORCHROOT=/home/tor-chroot
 
 # Prep the chroot
 mkdir -p $TORCHROOT
-mkdir -p $TORCHROOT/{etc/tor/,dev,lib,var/run/tor/,var/lib/tor/,var/log/tor/}/
+mkdir -p $TORCHROOT/{root,etc/tor/,dev,lib,var/run/tor/,var/lib/tor/,var/log/tor/}/
 chown debian-tor:debian-tor $TORCHROOT{/var/lib/tor,/var/run/tor,/var/log/tor}
 chmod 750 $TORCHROOT{/var/lib/tor,/var/run/tor,/var/log/tor}
 ls -al $TORCHROOT{/var/lib/tor,/var/run/tor,/var/log/tor}

--- a/tor-chroot-update.sh
+++ b/tor-chroot-update.sh
@@ -16,21 +16,21 @@ ls -al $TORCHROOT{/var/lib/tor,/var/run/tor,/var/log/tor}
 # Copy over the libs for Tor
 # Discover this with "ldd `which tor`"
 mkdir -p $TORCHROOT{/lib,/usr/lib/,/lib64/}
-cp /usr/lib/libz.so.1 $TORCHROOT/usr/lib/libz.so.1
-cp /lib/libm.so.6 $TORCHROOT/lib/libm.so.6
-cp /usr/lib/libevent-1.4.so.2 $TORCHROOT/usr/lib/libevent-1.4.so.2
-cp /usr/lib/libssl.so.0.9.8 $TORCHROOT/usr/lib/libssl.so.0.9.8
-cp /usr/lib/libcrypto.so.0.9.8 $TORCHROOT/usr/lib/libcrypto.so.0.9.8
-cp /lib/libpthread.so.0 $TORCHROOT/lib/libpthread.so.0
-cp /lib/libdl.so.2 $TORCHROOT/lib/libdl.so.2
-cp /lib/libc.so.6 $TORCHROOT/lib/libc.so.6
-cp /lib/libnsl.so.1 $TORCHROOT/lib/libnsl.so.1
-cp /lib/librt.so.1 $TORCHROOT/lib/librt.so.1
-cp /lib/libresolv.so.2 $TORCHROOT/lib/libresolv.so.2
-cp /lib64/ld-linux-x86-64.so.2 $TORCHROOT/lib64/ld-linux-x86-64.so.2
+cp /lib/x86_64-linux-gnu/libz.so.1 $TORCHROOT/usr/lib/libz.so.1
+cp /lib/x86_64-linux-gnu/libm.so.6 $TORCHROOT/lib/libm.so.6
+cp /usr/lib/x86_64-linux-gnu/libevent-2.0.so.5 $TORCHROOT/usr/lib/libevent-2.0.so.5
+cp /usr/lib/x86_64-linux-gnu/libssl.so.1.0.0 $TORCHROOT/usr/lib/libssl.so.1.0.0
+cp /usr/lib/x86_64-linux-gnu/libcrypto.so.1.0.0 $TORCHROOT/usr/lib/libcrypto.so.1.0.0
+cp /lib/x86_64-linux-gnu/libpthread.so.0 $TORCHROOT/lib/libpthread.so.0
+cp /lib/x86_64-linux-gnu/libdl.so.2 $TORCHROOT/lib/libdl.so.2
+cp /lib/x86_64-linux-gnu/libc.so.6 $TORCHROOT/lib/libc.so.6
+cp /lib/x86_64-linux-gnu/libnsl.so.1 $TORCHROOT/lib/libnsl.so.1
+cp /lib/x86_64-linux-gnu/librt.so.1 $TORCHROOT/lib/librt.so.1
+cp /lib/x86_64-linux-gnu/libresolv.so.2 $TORCHROOT/lib/libresolv.so.2
+cp /lib/x86_64-linux-gnu/ld-linux-x86-64.so.2 $TORCHROOT/lib64/ld-linux-x86-64.so.2
 
 # More generic libs
-cp /lib/libnss* /lib/libnsl* /lib/ld-linux.so.2 /lib/libresolv* \
+cp /lib/x86_64-linux-gnu/libnss* /lib/x86_64-linux-gnu/libnsl* /lib/x86_64-linux-gnu/libresolv* \
    $TORCHROOT/lib
 
 # Copy over Tor
@@ -68,8 +68,8 @@ mknod -m 644 $TORCHROOT/dev/urandom c 1 9
 mknod -m 666 $TORCHROOT/dev/null c 1 3
 
 # copy over the passwd/group and other system configs
-echo "debian-tor:x:106:107::/var/lib/tor:/bin/false" > $TORCHROOT/etc/passwd
-echo "debian-tor:x:107:" > $TORCHROOT/etc/group
+grep debian-tor /etc/passwd > $TORCHROOT/etc/passwd
+grep debian-tor /etc/group > $TORCHROOT/etc/group
 
 cp /etc/nsswitch.conf /etc/host.conf /etc/resolv.conf /etc/hosts $TORCHROOT/etc/
 cp /etc/localtime $TORCHROOT/etc

--- a/tor-chroot.sh
+++ b/tor-chroot.sh
@@ -22,4 +22,4 @@ if [ -f $DEFAULTSFILE ] ; then
 fi
 
 echo "Trying to chroot into $TORCHROOT..."
-/usr/sbin/chroot $TORCHROOT /usr/sbin/tor $*
+/usr/sbin/chroot --userspec=debian-tor:debian-tor $TORCHROOT /usr/sbin/tor $*


### PR DESCRIPTION
this patch updates tor-chroot-update.sh for updated
paths in /lib, /lib64 and /usr/lib.

we also switch from hardcoded passwd and group entries
to copying those already in group and passwd.
